### PR TITLE
Auto-register dtypes as UDTs.

### DIFF
--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -971,8 +971,6 @@ class UnaryOp(OpBase):
         sig = (dtype.numba_type,)
         numba_func.compile(sig)  # Should we catch and give additional error message?
         ret_type = lookup_dtype(numba_func.overloads[sig].signature.return_type)
-        if ret_type is not dtype and ret_type.gb_obj is dtype.gb_obj:
-            ret_type = dtype
 
         unary_wrapper, wrapper_sig = _get_udt_wrapper(numba_func, ret_type, dtype)
         unary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(unary_wrapper)
@@ -1553,11 +1551,6 @@ class BinaryOp(OpBase):
             sig = (dtype.numba_type, dtype2.numba_type)
             numba_func.compile(sig)  # Should we catch and give additional error message?
             ret_type = lookup_dtype(numba_func.overloads[sig].signature.return_type)
-            if ret_type is not dtype and ret_type is not dtype2:
-                if ret_type.gb_obj is dtype.gb_obj:
-                    ret_type = dtype
-                elif ret_type.gb_obj is dtype2.gb_obj:
-                    ret_type = dtype2
             binary_wrapper, wrapper_sig = _get_udt_wrapper(numba_func, ret_type, dtype, dtype2)
 
         binary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(binary_wrapper)

--- a/graphblas/tests/test_dtype.py
+++ b/graphblas/tests/test_dtype.py
@@ -188,3 +188,9 @@ def test_bad_register():
         dtypes.register_new("register_new", record_dtype)
     with pytest.raises(ValueError, match="name"):
         dtypes.register_new("UINT8", record_dtype)
+
+
+def test_auto_register():
+    n = np.random.randint(10, 64)
+    np_type = np.dtype(f"({n},)int16")
+    assert lookup_dtype(np_type).np_type == np_type


### PR DESCRIPTION
Also, only have a single object for each `numpy.dtype` for UDTs.  This makes it easier and less awkward for us, but could result in weirdness if the same dtype is registered multiple times under different names.  Probably okay.